### PR TITLE
Handle enviorment for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Intallation](#Intallation)
 - [Properties](#Properties)
 - [Development](#Development)
+- [How to Contribute ❤️ ](#how-to-contribute)
 
 # Introduction
 
@@ -51,7 +52,7 @@ For the design I have been heavily inspired by the awesome [vacuum-card](https:/
 
 There are currently no Configuration UI, copy the yaml from below to and modify the properties to fit your installation.
 
-**Configuration example:**
+### Configuration example
 
 ```yaml
 type: "custom:octoprint-card"
@@ -120,4 +121,44 @@ Starting a print for existing g-code.
 
 # How to Contribute
 
-Coming Soon™
+I Would love to wee what ideas you have. Any contributions are happily welcomed!
+
+1. Fork the repo.
+2. Make your changes on your fork ([How to run locally](#Running-locally))
+3. Open a Pull Request from your fork against the main branch.
+4. Remember to add a nice description of what your changes are intended to do.
+5. I will get back to you as soon as possible!
+
+## Running locally
+
+1. Clone this repository to your local machine
+
+```
+git clone https://github.com/kasperlaursen/octoprint-card.git
+```
+
+2. Go to the folder
+
+```
+cd octoprint-card
+```
+
+3. Install dependencies
+
+```
+npm install
+```
+
+3. Start the local development server, which will recompile the code on file changes.
+
+```
+npm run dev
+```
+
+4. Add the dev card to your Lovelace resources using the url `http://localhost:5000/octoprint-card-dev.js`
+
+5. Add the card to your dashboard with `type: 'custom:octoprint-card-dev'` and the rest of [the config](#Configuration-example)
+
+## Prerequisite
+
+To run the project locally you need to have [node.js](https://nodejs.org/en/) installed on your machine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "svelte-app",
-  "version": "1.0.0",
+  "name": "octoprint-card",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "svelte-app",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "dependencies": {
+        "@rollup/plugin-replace": "^2.4.2",
         "custom-card-helpers": "^1.7.0",
         "sirv-cli": "^1.0.0"
       },
@@ -117,6 +117,18 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
@@ -139,7 +151,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -155,8 +166,7 @@
     "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@tsconfig/svelte": {
       "version": "1.0.10",
@@ -167,8 +177,7 @@
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@types/node": {
       "version": "14.14.37",
@@ -762,7 +771,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -874,7 +882,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1148,8 +1155,7 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -1523,6 +1529,15 @@
         "resolve": "^1.19.0"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      }
+    },
     "@rollup/plugin-typescript": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
@@ -1537,7 +1552,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -1547,8 +1561,7 @@
         "estree-walker": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
         }
       }
     },
@@ -1561,8 +1574,7 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/node": {
       "version": "14.14.37",
@@ -2038,7 +2050,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -2125,8 +2136,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -2325,8 +2335,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "strip-indent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^4.0.0"
   },
   "dependencies": {
+    "@rollup/plugin-replace": "^2.4.2",
     "custom-card-helpers": "^1.7.0",
     "sirv-cli": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public --no-clear",
+    "start": "sirv public --cors --no-clear",
     "validate": "svelte-check"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 import sveltePreprocess from "svelte-preprocess";
 import typescript from "@rollup/plugin-typescript";
+import replace from "@rollup/plugin-replace";
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -38,9 +39,14 @@ export default {
     sourcemap: !production,
     format: "umd",
     name: "OctoprintCard",
-    file: "public/octoprint-card.js",
+    file: production
+      ? "public/octoprint-card.js"
+      : "public/octoprint-card-dev.js",
   },
   plugins: [
+    replace({
+      opc: production ? "octoprint-card" : "octoprint-card-dev",
+    }),
     svelte({
       preprocess: sveltePreprocess({ sourceMap: !production }),
       compilerOptions: {

--- a/src/OctoprintCard.svelte
+++ b/src/OctoprintCard.svelte
@@ -1,4 +1,4 @@
-<svelte:options tag="octoprint-card" />
+<svelte:options tag="opc" />
 
 <script lang="ts">
   import Preview from "./Preview.svelte"; // Needs import to work!
@@ -54,7 +54,7 @@
 </script>
 
 <ha-card class="parent">
-  <octoprint-card-preview {state} image={config.imageUrl} />
+  <opc-preview {state} image={config.imageUrl} />
   <div class="actions">
     {#if config.octoPrintUrl}
       <a href={config.octoPrintUrl} target="_blank"

--- a/src/Preview.svelte
+++ b/src/Preview.svelte
@@ -1,4 +1,4 @@
-<svelte:options tag="octoprint-card-preview" />
+<svelte:options tag="opc-preview" />
 
 <script lang="ts">
   import Time from "./components/Time.svelte";

--- a/src/components/Temperature.svelte
+++ b/src/components/Temperature.svelte
@@ -1,4 +1,4 @@
-<svelte:options tag="octoprint-card-temperature" />
+<svelte:options tag="opc-temperature" />
 
 <script lang="ts">
   export let actual: { value: string; unit: string };

--- a/src/components/Time.svelte
+++ b/src/components/Time.svelte
@@ -1,4 +1,4 @@
-<svelte:options tag="octoprint-card-time" />
+<svelte:options tag="opc-time" />
 
 <script lang="ts">
   import { afterUpdate } from "svelte";

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ declare global {
 
 window.customCards = window.customCards || [];
 window.customCards.push({
-  type: "octoprint-card",
+  type: "opc",
   name: "Octoprint Card",
   preview: false,
   description: "Octoprint card",


### PR DESCRIPTION
As part of #6 this PR makes it possible to differentiate between a production and development build and run both in the same Home Assistant instance! 
This is done by replacing `opc` in all files with `octoprint-card`  or `octoprint-card-dev` as a build step. 

This means that you can use `npm run dev` and add the resource `http://localhost:5000/octoprint-card-dev.js`.
After this add the card `type: 'custom:octoprint-card-dev'` to your dashboard. 

**Cons**: This means that all custom elements must be prefixed with `opc`.